### PR TITLE
[FIX] Fix url encoding, url nil if send selfPromotion touch

### DIFF
--- a/Tracker/Tracker/ATSender.m
+++ b/Tracker/Tracker/ATSender.m
@@ -181,7 +181,7 @@ static BOOL sentWithSuccess = NO;
         
     } else {
         
-        NSURL *url = [NSURL URLWithString:self.hit.url];
+        NSURL *url = [NSURL URLWithString:[self.hit.url stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
         
         if (url) {
             


### PR DESCRIPTION
Hello,

When we send SelfPromotion touch, the url of the object ATSelfPromotion has doubleSeprator "||" (line 58)

```
NSString *doubleSeparator = @"||";
```

So, we need  escapes some characters.
