### PR TITLE
Feature/podspec split

### DIFF
--- a/ATInternet-iOS-ObjC-SDK-AppExtension.podspec
+++ b/ATInternet-iOS-ObjC-SDK-AppExtension.podspec
@@ -7,15 +7,10 @@ Pod::Spec.new do |s|
 	s.license      = "MIT"
 	s.author     = "AT Internet"
 	s.platform = :ios
-  	s.ios.deployment_target = '7.0'
-
+  s.ios.deployment_target = '7.0'
 	s.source       = { :git => "https://github.com/summerize/atinternet-ios-objc-sdk.git", :tag => s.version}
 	s.prefix_header_file = "Tracker/Tracker/ATTracker-prefix.pch"
-
-	s.subspec 'Res' do |res|
-		res.resource_bundle = {'ATAssets' => ['Tracker/Tracker/*.{xcdatamodeld,png,json}','Tracker/Tracker/ATDefaultConfiguration.plist']}
-	end
-
+	s.resource_bundle = {'ATAssets' => ['Tracker/Tracker/*.{xcdatamodeld,png,json}','Tracker/Tracker/ATDefaultConfiguration.plist']}
 	s.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) AT_EXTENSION'}
 	s.source_files  = "Tracker/Tracker/*.{h,m}"
 	s.exclude_files = "Tracker/Tracker/ATBackgroundTask.{h,m}"

--- a/ATInternet-iOS-ObjC-SDK-AppExtension.podspec
+++ b/ATInternet-iOS-ObjC-SDK-AppExtension.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-	s.name         = "ATInternet-iOS-ObjC-SDK"
+	s.name         = "ATInternet-iOS-ObjC-SDK-AppExtension"
 	s.version      = '2.2.7.1'
 	s.summary      = "AT Internet mobile analytics solution for iOS"
 	s.homepage     = "https://github.com/at-internet/atinternet-ios-objc-sdk"
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
 	s.license      = "MIT"
 	s.author     = "AT Internet"
 	s.platform = :ios
-  	s.ios.deployment_target = '7.0'
+  s.ios.deployment_target = '7.0'
 
 	s.source       = { :git => "https://github.com/summerize/atinternet-ios-objc-sdk.git", :tag => s.version}
 	s.prefix_header_file = "Tracker/Tracker/ATTracker-prefix.pch"
@@ -16,10 +16,10 @@ Pod::Spec.new do |s|
 		res.resource_bundle = {'ATAssets' => ['Tracker/Tracker/*.{xcdatamodeld,png,json}','Tracker/Tracker/ATDefaultConfiguration.plist']}
 	end
 
-	s.subspec 'iOS' do |ios|
-		ios.source_files  = "Tracker/Tracker/*.{h,m}"
-		ios.frameworks = "CoreData", "CoreFoundation", "UIKit", "CoreTelephony", "SystemConfiguration"
-		ios.dependency s.name+'/Res'
-	end
+	s.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) AT_EXTENSION'}
+	s.source_files  = "Tracker/Tracker/*.{h,m}"
+	s.exclude_files = "Tracker/Tracker/ATBackgroundTask.{h,m}"
+	s.frameworks = "CoreData", "CoreFoundation", "WatchKit", "UIKit", "CoreTelephony", "SystemConfiguration"
+	s.dependency s.name+'/Res'
 	s.requires_arc = true
 end

--- a/ATInternet-iOS-ObjC-SDK-AppExtension.podspec
+++ b/ATInternet-iOS-ObjC-SDK-AppExtension.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
 	s.license      = "MIT"
 	s.author     = "AT Internet"
 	s.platform = :ios
-  s.ios.deployment_target = '7.0'
+  	s.ios.deployment_target = '7.0'
 
 	s.source       = { :git => "https://github.com/summerize/atinternet-ios-objc-sdk.git", :tag => s.version}
 	s.prefix_header_file = "Tracker/Tracker/ATTracker-prefix.pch"

--- a/ATInternet-iOS-ObjC-SDK-AppExtension.podspec
+++ b/ATInternet-iOS-ObjC-SDK-AppExtension.podspec
@@ -15,6 +15,5 @@ Pod::Spec.new do |s|
 	s.source_files  = "Tracker/Tracker/*.{h,m}"
 	s.exclude_files = "Tracker/Tracker/ATBackgroundTask.{h,m}"
 	s.frameworks = "CoreData", "CoreFoundation", "WatchKit", "UIKit", "CoreTelephony", "SystemConfiguration"
-	s.dependency s.name+'/Res'
 	s.requires_arc = true
 end

--- a/ATInternet-iOS-ObjC-SDK-AppExtension.podspec
+++ b/ATInternet-iOS-ObjC-SDK-AppExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name         = "ATInternet-iOS-ObjC-SDK-AppExtension"
-	s.version      = '2.2.7.1'
+	s.version      = '2.2.7.3'
 	s.summary      = "AT Internet mobile analytics solution for iOS"
 	s.homepage     = "https://github.com/at-internet/atinternet-ios-objc-sdk"
 	s.documentation_url = 'http://developers.atinternet-solutions.com/apple-en/getting-started-apple-en/operating-principle-apple-en/'

--- a/ATInternet-iOS-ObjC-SDK.podspec
+++ b/ATInternet-iOS-ObjC-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name         = "ATInternet-iOS-ObjC-SDK"
-	s.version      = ‘2.2.7’
+	s.version      = ‘1.0’
 	s.summary      = "AT Internet mobile analytics solution for iOS"
 	s.homepage     = "https://github.com/at-internet/atinternet-ios-objc-sdk"
 	s.documentation_url = 'http://developers.atinternet-solutions.com/apple-en/getting-started-apple-en/operating-principle-apple-en/'
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
 	s.platform = :ios
   	s.ios.deployment_target = '7.0'
 
-	s.source       = { :git => "https://github.com/at-internet/atinternet-ios-objc-sdk.git", :tag => s.version}
+	s.source       = { :git => "https://github.com/summerize/atinternet-ios-objc-sdk.git", :tag => s.version}
 	s.prefix_header_file = "Tracker/Tracker/ATTracker-prefix.pch"
 
 	s.subspec 'Res' do |res|

--- a/ATInternet-iOS-ObjC-SDK.podspec
+++ b/ATInternet-iOS-ObjC-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name         = "ATInternet-iOS-ObjC-SDK"
-	s.version      = ‘1.0’
+	s.version      = '2.2.7.1'
 	s.summary      = "AT Internet mobile analytics solution for iOS"
 	s.homepage     = "https://github.com/at-internet/atinternet-ios-objc-sdk"
 	s.documentation_url = 'http://developers.atinternet-solutions.com/apple-en/getting-started-apple-en/operating-principle-apple-en/'

--- a/ATInternet-iOS-ObjC-SDK.podspec
+++ b/ATInternet-iOS-ObjC-SDK.podspec
@@ -15,7 +15,6 @@ Pod::Spec.new do |s|
 	s.subspec 'iOS' do |ios|
 		ios.source_files  = "Tracker/Tracker/*.{h,m}"
 		ios.frameworks = "CoreData", "CoreFoundation", "UIKit", "CoreTelephony", "SystemConfiguration"
-		ios.dependency s.name+'/Res'
 	end
 
 	s.requires_arc = true

--- a/ATInternet-iOS-ObjC-SDK.podspec
+++ b/ATInternet-iOS-ObjC-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name         = "ATInternet-iOS-ObjC-SDK"
-	s.version      = '2.2.7.1'
+	s.version      = '2.2.7.3'
 	s.summary      = "AT Internet mobile analytics solution for iOS"
 	s.homepage     = "https://github.com/at-internet/atinternet-ios-objc-sdk"
 	s.documentation_url = 'http://developers.atinternet-solutions.com/apple-en/getting-started-apple-en/operating-principle-apple-en/'

--- a/ATInternet-iOS-ObjC-SDK.podspec
+++ b/ATInternet-iOS-ObjC-SDK.podspec
@@ -7,19 +7,16 @@ Pod::Spec.new do |s|
 	s.license      = "MIT"
 	s.author     = "AT Internet"
 	s.platform = :ios
-  	s.ios.deployment_target = '7.0'
-
+  s.ios.deployment_target = '7.0'
 	s.source       = { :git => "https://github.com/summerize/atinternet-ios-objc-sdk.git", :tag => s.version}
 	s.prefix_header_file = "Tracker/Tracker/ATTracker-prefix.pch"
-
-	s.subspec 'Res' do |res|
-		res.resource_bundle = {'ATAssets' => ['Tracker/Tracker/*.{xcdatamodeld,png,json}','Tracker/Tracker/ATDefaultConfiguration.plist']}
-	end
+	s.resource_bundle = {'ATAssets' => ['Tracker/Tracker/*.{xcdatamodeld,png,json}','Tracker/Tracker/ATDefaultConfiguration.plist']}
 
 	s.subspec 'iOS' do |ios|
 		ios.source_files  = "Tracker/Tracker/*.{h,m}"
 		ios.frameworks = "CoreData", "CoreFoundation", "UIKit", "CoreTelephony", "SystemConfiguration"
 		ios.dependency s.name+'/Res'
 	end
+
 	s.requires_arc = true
 end

--- a/Tracker/Tracker.xcodeproj/xcuserdata/jeromemorissard.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Tracker/Tracker.xcodeproj/xcuserdata/jeromemorissard.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>4F53DF5F1A8E140A009C6B44</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>AEDFEE501B2599EA00756827</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>AEF293121A4343AB00B0034E</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>AEF2931D1A4343AB00B0034E</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Tracker/Tracker/ATBackgroundTask.m
+++ b/Tracker/Tracker/ATBackgroundTask.m
@@ -76,9 +76,7 @@ typedef void (^CompletionBlock)();
 
 - (NSUInteger)beginTaskWithCompletionHandler:(CompletionBlock)_completion;
 {
-#if defined AT_EXTENSION
-    return 0
-#else 
+#ifndef AT_EXTENSION
     //read the counter and increment it
     NSUInteger taskKey;
     @synchronized(self) {
@@ -102,13 +100,12 @@ typedef void (^CompletionBlock)();
     //return the dictionary key
     return taskKey;
 #endif
+    return 0;
 }
 
 - (void)endTaskWithKey:(NSUInteger)_key
 {
-#if defined AT_EXTENSION
-   return
-#else
+#ifndef AT_EXTENSION
     @synchronized(self.tasksCompletionBlocks) {
         
         //see if this task has a completion block
@@ -145,7 +142,7 @@ typedef void (^CompletionBlock)();
         }
         
     }
-#end
+#endif
 }
 
 @end

--- a/Tracker/Tracker/ATBackgroundTask.m
+++ b/Tracker/Tracker/ATBackgroundTask.m
@@ -76,6 +76,9 @@ typedef void (^CompletionBlock)();
 
 - (NSUInteger)beginTaskWithCompletionHandler:(CompletionBlock)_completion;
 {
+#if defined AT_EXTENSION
+    return 0
+#else 
     //read the counter and increment it
     NSUInteger taskKey;
     @synchronized(self) {
@@ -98,10 +101,14 @@ typedef void (^CompletionBlock)();
     
     //return the dictionary key
     return taskKey;
+#endif
 }
 
 - (void)endTaskWithKey:(NSUInteger)_key
 {
+#if defined AT_EXTENSION
+   return
+#else
     @synchronized(self.tasksCompletionBlocks) {
         
         //see if this task has a completion block
@@ -138,6 +145,7 @@ typedef void (^CompletionBlock)();
         }
         
     }
+#end
 }
 
 @end

--- a/Tracker/Tracker/ATBackgroundTask.m
+++ b/Tracker/Tracker/ATBackgroundTask.m
@@ -76,56 +76,52 @@ typedef void (^CompletionBlock)();
 
 - (NSUInteger)beginTaskWithCompletionHandler:(CompletionBlock)_completion;
 {
-#ifndef AT_EXTENSION
     //read the counter and increment it
     NSUInteger taskKey;
     @synchronized(self) {
-        
+
         taskKey = self.taskCounter;
         self.taskCounter++;
-        
+
     }
-    
+
     //tell the OS to start a task that should continue in the background if needed
     NSUInteger taskId = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
         [self endTaskWithKey:taskKey];
     }];
-    
+
     //add this task identifier to the active task dictionary
     [self.tasks setObject:[NSNumber numberWithUnsignedLong:taskId] forKey:[NSNumber numberWithUnsignedLong:taskKey]];
-    
+
     //store the completion block (if any)
     if (_completion) [self.tasksCompletionBlocks setObject:_completion forKey:[NSNumber numberWithUnsignedLong:taskKey]];
-    
+
     //return the dictionary key
     return taskKey;
-#endif
-    return 0;
 }
 
 - (void)endTaskWithKey:(NSUInteger)_key
 {
-#ifndef AT_EXTENSION
     @synchronized(self.tasksCompletionBlocks) {
-        
+
         //see if this task has a completion block
         CompletionBlock completion = [self.tasksCompletionBlocks objectForKey:[NSNumber numberWithUnsignedLong:_key]];
         if (completion) {
-            
+
             //run the completion block and remove it from the completion block dictionary
             completion();
             [self.tasksCompletionBlocks removeObjectForKey:[NSNumber numberWithUnsignedLong:_key]];
-            
+
         }
-        
+
     }
-    
+
     @synchronized(self.tasks) {
-        
+
         //see if this task has been ended yet
         NSNumber *taskId = [self.tasks objectForKey:[NSNumber numberWithUnsignedLong:_key]];
         if (taskId) {
-            
+
             for (NSOperation *operation in [ATTrackerQueue sharedInstance].queue.operations) {
                 if([operation isKindOfClass:[ATSender class]]){
                     ATSender *sender = (ATSender *) operation;
@@ -134,15 +130,14 @@ typedef void (^CompletionBlock)();
                     }
                 }
             }
-            
+
             //end the task and remove it from the active task dictionary
             [[UIApplication sharedApplication] endBackgroundTask:[taskId unsignedLongValue]];
             [self.tasks removeObjectForKey:[NSNumber numberWithUnsignedLong:_key]];
-            
+
         }
-        
+
     }
-#endif
 }
 
 @end

--- a/Tracker/Tracker/ATTracker.m
+++ b/Tracker/Tracker/ATTracker.m
@@ -316,6 +316,8 @@ static BOOL _handleCrash = NO;
 
 - (instancetype)init:(NSMutableDictionary *)configuration {
     if (self = [super init]) {
+#if defined AT_EXTENSION
+#else
         self.buffer = [[ATBuffer alloc] initWithTracker:self];
         self.configuration = [[ATConfiguration alloc] initWithDictionary: configuration];
         if(![ATLifeCycle isInitialized]){
@@ -327,6 +329,7 @@ static BOOL _handleCrash = NO;
         self.lifeCycle = [[ATLifeCycle alloc] init];
         self.businessObjects = [[NSMutableDictionary alloc] init];
         self.dispatcher = [[ATDispatcher alloc] initWithTracker:self];
+#endif
     }
     return self;
 }


### PR DESCRIPTION
Hi, 
Actually it's impossible to compile a project with target using differents subspec.
for exemple, 
TARGET A 
pod atinternet-ios-objc-sdk

TARGET B (an AppExtension)
pod atinternet-ios-objc-sdk/AppExtension 

=> compilation failed, conflict on frameworks names. 
subspec are not the right solution to compile a light framework for AppExtension because it's final name is the same has the full one integrated to app.

A good solution ? (my pull request), is to use 2 podspecs to generate 2 frameworks with distinct names.

PS : The same issue exists on the Swift version. (but the same fix could fix it)